### PR TITLE
Implement configurable domain-based post filtering

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,27 @@
+let tabData = {};
+
+browser.runtime.onMessage.addListener((message, sender) => {
+  if (message.type === 'incrementCount') {
+    const tabId = sender.tab.id;
+    if (!tabData[tabId]) {
+      tabData[tabId] = { domain: message.domain, count: 0 };
+    }
+    tabData[tabId].count += message.amount || 0;
+  } else if (message.type === 'getCount') {
+    const tabId = message.tabId;
+    return Promise.resolve(tabData[tabId] ? tabData[tabId].count : 0);
+  }
+});
+
+browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (changeInfo.url) {
+    const domain = new URL(changeInfo.url).hostname.replace(/^www\./, '');
+    if (!tabData[tabId] || tabData[tabId].domain !== domain) {
+      tabData[tabId] = { domain, count: 0 };
+    }
+  }
+});
+
+browser.tabs.onRemoved.addListener(tabId => {
+  delete tabData[tabId];
+});

--- a/content_script.js
+++ b/content_script.js
@@ -29,12 +29,21 @@ if (!currentSelector) {
     const posts = document.querySelectorAll(currentSelector);
     let filteredCount = 0;
     posts.forEach(post => {
+      if (post.dataset.postFiltered) {
+        return;
+      }
       if (containsFilterWord(post.innerText)) {
         filteredCount += 1;
         post.style.display = 'none';
+        post.dataset.postFiltered = 'true';
       }
     });
     if (filteredCount) {
+      browser.runtime.sendMessage({
+        type: 'incrementCount',
+        domain: domain,
+        amount: filteredCount
+      });
       console.log('WordFilter:', 'Filtered', filteredCount, 'posts on', domain);
     }
   }

--- a/content_script.js
+++ b/content_script.js
@@ -1,95 +1,55 @@
-const SITES = {
-  'reddit': {
-    url: '*://www.reddit.com/*',
-    selector: 'article',
-  },
-  'facebook': {
-    url: '*://www.facebook.com/*',
-    selector: 'div[data-pagelet^="FeedUnit_"]',
-  },
-  'instagram': {
-    url: '*://www.instagram.com/*',
-    selector: 'article div[role="button"] span',
-  },
-  'tiktok': {
-    url: '*://www.tiktok.com/*',
-    selector: 'div.tiktok-1p6exx2-DivItemContainer',
-  },
-  'twitter': {
-    url: '*://twitter.com/*',
-    selector: 'article[role="article"]',
-  },
+const DOMAIN_SELECTORS = {
+  'reddit.com': 'article',
+  'twitter.com': 'article[role="article"]',
+  'facebook.com': 'div[data-pagelet^="FeedUnit_"]',
+  'instagram.com': 'article div[role="button"] span',
+  'tiktok.com': 'div.tiktok-1p6exx2-DivItemContainer',
 };
 
-let currentSelector = ''; // Will hold the selector for the current site
+const domain = window.location.hostname.replace(/^www\./, '');
+const currentSelector = DOMAIN_SELECTORS[domain];
 
-// Determine the current selector based on the current URL
-const currentUrl = window.location.href;
-for (let siteKey in SITES) {
-  const site = SITES[siteKey];
-  const urlPattern = new RegExp(site.url.replace(/\*/g, '.*'));
-  if (urlPattern.test(currentUrl)) {
-    currentSelector = site.selector;
-    break;
-  }
-}
-console.log('currentSelector:', currentSelector);
-console.log('currentUrl:', currentUrl);
-
-// If no matching site is found, exit the script
 if (!currentSelector) {
-  console.log('No matching site found for filtering.');
+  console.log('No matching site found for filtering on domain:', domain);
 } else {
-  // List of words to filter
-  let filterWords = [
-    "trump",
-    "vance",
-    "kamala",
-    "harris",
-    "biden",
-    // Add more words as needed
-  ];
+  let filterWords = [];
 
-  // Function to check if a text contains any of the filter words
+  function loadFilterWords() {
+    browser.storage.local.get(domain).then(result => {
+      filterWords = result[domain] || [];
+      filterContent();
+    });
+  }
+
   function containsFilterWord(text) {
     return filterWords.some(word => text.toLowerCase().includes(word.toLowerCase()));
   }
 
-  // Function to remove or hide elements containing filter words
   function filterContent() {
-    let posts = document.querySelectorAll(currentSelector);
-    console.log('WordFilter:', 'Found', posts.length, 'posts.');
-
+    const posts = document.querySelectorAll(currentSelector);
     let filteredCount = 0;
-    let filterCountByWord = {};
-    filterWords.forEach(word => {
-      filterCountByWord[word] = 0;
-    });
-
     posts.forEach(post => {
       if (containsFilterWord(post.innerText)) {
         filteredCount += 1;
-
-        // Increment filterCountByWord for each word found in the post
-        filterWords.forEach(word => {
-          if (post.innerText.toLowerCase().includes(word.toLowerCase())) {
-            filterCountByWord[word] += 1;
-          }
-        });
-
-        post.style.display = "none"; // Hide the post
+        post.style.display = 'none';
       }
     });
-
-    console.log('WordFilter:', 'Filtered', filteredCount, 'posts for containing words in the blacklist:');
-    console.log('Filter counts by word:', filterCountByWord);
+    if (filteredCount) {
+      console.log('WordFilter:', 'Filtered', filteredCount, 'posts on', domain);
+    }
   }
 
-  // Run the filter when the page loads
-  window.addEventListener("load", filterContent);
+  loadFilterWords();
 
-  // Observe for new content (e.g., infinite scrolling)
-  let observer = new MutationObserver(filterContent);
+  browser.storage.onChanged.addListener((changes, area) => {
+    if (area === 'local' && changes[domain]) {
+      filterWords = changes[domain].newValue || [];
+      filterContent();
+    }
+  });
+
+  window.addEventListener('load', filterContent);
+  const observer = new MutationObserver(filterContent);
   observer.observe(document.body, { childList: true, subtree: true });
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -6,12 +6,18 @@
   "icons": {
     "48": "icon.png"
   },
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
+  },
   "content_scripts": [
     {
       "matches": [
-        "*://www.reddit.com/*",
-        "*://twitter.com/*",
-        "*://www.facebook.com/*"
+        "*://*.reddit.com/*",
+        "*://*.twitter.com/*",
+        "*://*.facebook.com/*",
+        "*://*.instagram.com/*",
+        "*://*.tiktok.com/*"
       ],
       "js": ["content_script.js"],
       "css": ["styles.css"]

--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,13 @@
   "icons": {
     "48": "icon.png"
   },
+  "background": {
+    "scripts": ["background.js"]
+  },
+  "browser_action": {
+    "default_icon": "icon.png",
+    "default_popup": "popup.html"
+  },
   "options_ui": {
     "page": "options.html",
     "open_in_tab": true
@@ -24,7 +31,8 @@
     }
   ],
   "permissions": [
-    "storage"
+    "storage",
+    "tabs"
   ],
   "browser_specific_settings": {
     "gecko": {

--- a/options.html
+++ b/options.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Post Filter Settings</title>
+  <link rel="stylesheet" href="styles.css">
+  <style>
+    body { font-family: Arial, sans-serif; padding: 10px; }
+    .domain-entry { margin-bottom: 8px; }
+    textarea { width: 100%; height: 60px; }
+  </style>
+</head>
+<body>
+  <h1>Post Filter Settings</h1>
+  <div id="domain-list"></div>
+  <h2>Add or Edit Domain</h2>
+  <input id="domain-input" placeholder="Domain, e.g. reddit.com">
+  <br>
+  <textarea id="words-input" placeholder="Comma separated words"></textarea>
+  <br>
+  <button id="save-btn">Save</button>
+
+  <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,45 @@
+function renderDomains(data) {
+  const container = document.getElementById('domain-list');
+  container.innerHTML = '';
+  Object.keys(data).forEach(domain => {
+    const div = document.createElement('div');
+    div.className = 'domain-entry';
+    const span = document.createElement('span');
+    span.textContent = domain + ': ' + (data[domain] || []).join(', ');
+    const editBtn = document.createElement('button');
+    editBtn.textContent = 'Edit';
+    editBtn.addEventListener('click', () => {
+      document.getElementById('domain-input').value = domain;
+      document.getElementById('words-input').value = (data[domain] || []).join(', ');
+    });
+    const delBtn = document.createElement('button');
+    delBtn.textContent = 'Delete';
+    delBtn.addEventListener('click', () => {
+      browser.storage.local.remove(domain).then(loadDomains);
+    });
+    div.appendChild(span);
+    div.appendChild(editBtn);
+    div.appendChild(delBtn);
+    container.appendChild(div);
+  });
+}
+
+function loadDomains() {
+  browser.storage.local.get(null).then(renderDomains);
+}
+
+document.getElementById('save-btn').addEventListener('click', () => {
+  const domain = document.getElementById('domain-input').value.trim();
+  const words = document.getElementById('words-input').value.split(',').map(w => w.trim()).filter(w => w);
+  if (domain) {
+    const data = {};
+    data[domain] = words;
+    browser.storage.local.set(data).then(() => {
+      document.getElementById('domain-input').value = '';
+      document.getElementById('words-input').value = '';
+      loadDomains();
+    });
+  }
+});
+
+document.addEventListener('DOMContentLoaded', loadDomains);

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Filtered Posts Count</title>
+  <style>
+    body { width: 150px; font-family: Arial, sans-serif; }
+    #count { font-size: 24px; font-weight: bold; text-align: center; margin-top: 20px; }
+  </style>
+</head>
+<body>
+  <div>Filtered posts:</div>
+  <div id="count">0</div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,8 @@
+document.addEventListener('DOMContentLoaded', () => {
+  browser.tabs.query({active: true, currentWindow: true}).then(tabs => {
+    const tabId = tabs[0].id;
+    browser.runtime.sendMessage({type: 'getCount', tabId}).then(count => {
+      document.getElementById('count').textContent = count;
+    });
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,2 @@
+/* Placeholder styles for options page */
+button { margin-left: 4px; }


### PR DESCRIPTION
## Summary
- add domain selectors and load filter words from storage
- provide an options page to manage per-domain word lists
- hook up options page in the manifest
- add minimal styles

## Testing
- `bash script.sh` *(fails: missing token and CONNECT tunnel 403)*

------
https://chatgpt.com/codex/tasks/task_e_6848d815b1fc8329a99ce0bc3b8e4de0